### PR TITLE
Docker yml & Remove burned token from subgraph database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3'
+services:
+  graph-node:
+    container_name: zNS
+    image: graphprotocol/graph-node
+    ports:
+      - '8000:8000'
+      - '8001:8001'
+      - '8020:8020'
+      - '8030:8030'
+      - '8040:8040'
+    depends_on:
+      - ipfs
+      - postgres
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    environment:
+      postgres_host: postgres
+      postgres_user: graph-node
+      postgres_pass: let-me-in
+      postgres_db: graph-node
+      ipfs: 'ipfs:5001'
+      ethereum: "goerli:https://goerli.infura.io/v3/fa959ead3761429bafa6995a4b25397e"
+      GRAPH_LOG: info
+  ipfs:
+    image: ipfs/go-ipfs:v0.10.0
+    ports:
+      - '5001:5001'
+    volumes:
+      - ./data/ipfs:/Volumes/Data/Docker/ipfs
+  postgres:
+    image: postgres
+    ports:
+      - '5432:5432'
+    command:
+      [
+        "postgres",
+        "-cshared_preload_libraries=pg_stat_statements"
+      ]
+    environment:
+      POSTGRES_USER: graph-node
+      POSTGRES_PASSWORD: let-me-in
+      POSTGRES_DB: graph-node
+      PGDATA: "/data/postgres"
+    volumes:
+      - ./data/postgres:/Volumes/Data/Docker/postgresql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       postgres_pass: let-me-in
       postgres_db: graph-node
       ipfs: 'ipfs:5001'
-      ethereum: "goerli:https://goerli.infura.io/v3/fa959ead3761429bafa6995a4b25397e"
+      ethereum: "goerli:https://goerli.infura.io/v3/97e75e0bbc6a4419a5dd7fe4a518b917"
       GRAPH_LOG: info
   ipfs:
     image: ipfs/go-ipfs:v0.10.0

--- a/src/registrar.ts
+++ b/src/registrar.ts
@@ -1,4 +1,4 @@
-import { BigInt, log } from "@graphprotocol/graph-ts";
+import { BigInt, log, store } from "@graphprotocol/graph-ts";
 import {
   DomainCreated,
   Transfer,
@@ -22,7 +22,7 @@ import {
 } from "../generated/schema";
 import { getDefaultRegistrarForNetwork } from "./defaultRegistrar";
 
-import { toPaddedHexString, containsAny, setupGlobalTracker } from "./utils";
+import { toPaddedHexString, containsAny, setupGlobalTracker, ADDRESS_ZERO } from "./utils";
 
 export function handleDomainCreated(event: DomainCreated1): void {
   let account = new Account(event.params.minter.toHex());
@@ -96,17 +96,23 @@ export function handleTransfer(event: Transfer): void {
   registrarContract.save();
 
   let domainId = toPaddedHexString(event.params.tokenId);
-  let domain = Domain.load(domainId);
-  if (domain === null) {
-    domain = new Domain(domainId);
-    domain.isLocked = false;
-    domain.royaltyAmount = BigInt.fromI32(0);
+
+  if (account.id.localeCompare(ADDRESS_ZERO) === 0) {
+    // If burning token, remove domain from store
+    store.remove("Domain", domainId);
+  } else {
+    let domain = Domain.load(domainId);
+    if (domain === null) {
+      domain = new Domain(domainId);
+      domain.isLocked = false;
+      domain.royaltyAmount = BigInt.fromI32(0);
+    }
+    domain.owner = account.id;
+    if (domain.contract === null) {
+      domain.contract = getDefaultRegistrarForNetwork().toHexString();
+    }
+    domain.save();
   }
-  domain.owner = account.id;
-  if (domain.contract === null) {
-    domain.contract = getDefaultRegistrarForNetwork().toHexString();
-  }
-  domain.save();
 
   // ignore transfers to self
   if (event.params.to == event.params.from) {

--- a/src/registrar.ts
+++ b/src/registrar.ts
@@ -1,4 +1,4 @@
-import { BigInt, log, store } from "@graphprotocol/graph-ts";
+import { BigInt, log, store, Address } from "@graphprotocol/graph-ts";
 import {
   DomainCreated,
   Transfer,
@@ -97,7 +97,7 @@ export function handleTransfer(event: Transfer): void {
 
   let domainId = toPaddedHexString(event.params.tokenId);
 
-  if (account.id.localeCompare(ADDRESS_ZERO) === 0) {
+  if (event.params.to.equals(ADDRESS_ZERO)) {
     // If burning token, remove domain from store
     store.remove("Domain", domainId);
   } else {

--- a/src/registrar.ts
+++ b/src/registrar.ts
@@ -1,4 +1,4 @@
-import { BigInt, log, store, Address } from "@graphprotocol/graph-ts";
+import { BigInt, log, store } from "@graphprotocol/graph-ts";
 import {
   DomainCreated,
   Transfer,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ import {
 import { Domain, Global } from "../generated/schema";
 import { RegExp } from "./lib/assemblyscript-regex/assembly";
 
-export const ADDRESS_ZERO = "0x0000000000000000000000000000000000000000";
+export const ADDRESS_ZERO = Address.zero();
 
 export function byteArrayFromHex(s: string): ByteArray {
   if (s.length % 2 !== 0) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,8 @@ import {
 import { Domain, Global } from "../generated/schema";
 import { RegExp } from "./lib/assemblyscript-regex/assembly";
 
+export const ADDRESS_ZERO = "0x0000000000000000000000000000000000000000";
+
 export function byteArrayFromHex(s: string): ByteArray {
   if (s.length % 2 !== 0) {
     throw new TypeError("Hex string must have an even number of characters");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1765,9 +1765,9 @@ globby@^11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-"gluegun@git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep":
+"gluegun@https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep":
   version "4.3.1"
-  resolved "git+https://github.com/edgeandnode/gluegun.git#b34b9003d7bf556836da41b57ef36eb21570620a"
+  resolved "https://github.com/edgeandnode/gluegun#b34b9003d7bf556836da41b57ef36eb21570620a"
   dependencies:
     apisauce "^1.0.1"
     app-module-path "^2.2.0"


### PR DESCRIPTION
**Description**

In the zNS-subgraph, burned `domain` still remains.
In the `zero.live`, it is fetching payment token from `zAuction-sdk` by calling `getPaymentTokenFromDomain` function which fails on burned domains(not existing domains), this leads to the error in the frontend.

**How to reproduce**
Burn any domain in `Registrar` by calling `adminBurnToken`, open `zero.live` page and check if it fails.

**How to fix**
Burned token should be removed from subgraph store.


**Commits**
- docker compose yaml configuration file for local docker testing
- Remove burned domain from database